### PR TITLE
Updated vosonDash to support vosonSML v0.26

### DIFF
--- a/VOSONDash/global.R
+++ b/VOSONDash/global.R
@@ -1,8 +1,8 @@
 # voson dashboard shiny app globals
 
 # app version
-app_version <- "v0.3.1"
-app_date <- "07Feb19"
+app_version <- "v0.3.2"
+app_date <- "17Feb19"
 
 # app libraries
 library(shiny)

--- a/VOSONDash/global.R
+++ b/VOSONDash/global.R
@@ -1,7 +1,7 @@
 # voson dashboard shiny app globals
 
 # app version
-app_version <- "v0.3.2"
+app_version <- "v0.3.3"
 app_date <- "17Feb19"
 
 # app libraries

--- a/VOSONDash/server/networkGraphsServer.R
+++ b/VOSONDash/server/networkGraphsServer.R
@@ -589,7 +589,7 @@ visNetworkData <- reactive({
   }
 
   verts$id <- verts$name
-  verts$label <- verts$name
+  # verts$label <- verts$name
   
   # if (input$graph_names_check == FALSE) {
   #   verts <- subset(verts, select = -c(label))
@@ -663,6 +663,9 @@ dt_vertices_df <- reactive({
   df_parameters <- list()
   
   df_parameters[['name']] <- V(g)$name
+  if (!(is.null(vertex_attr(g, "label")))) {
+    df_parameters[['label']] <- V(g)$label
+  }  
   df_parameters[['degree']] <- V(g)$Degree
   df_parameters[['indegree']] <- V(g)$Indegree
   df_parameters[['outdegree']] <- V(g)$Outdegree
@@ -726,7 +729,7 @@ standardPlotData <- reactive({
   })
   selected_rows <- input$dt_vertices_rows_selected
   # graph_vertices <- as_data_frame(g, what = c("vertices"))
-  df <- data.frame(name = V(g)$name, degree = V(g)$Degree, indegree = V(g)$Indegree, outdegree = V(g)$Outdegree, betweenness = V(g)$Betweenness, closeness = V(g)$Closeness)
+  df <- data.frame(label = V(g)$label, name = V(g)$name, degree = V(g)$Degree, indegree = V(g)$Indegree, outdegree = V(g)$Outdegree, betweenness = V(g)$Betweenness, closeness = V(g)$Closeness)
   row.names(df) <- V(g)$id
   graph_vertices <- df
   # g <- graph.data.frame(relations, directed=TRUE, vertices=actorsNames)
@@ -795,10 +798,23 @@ standardPlotData <- reactive({
   plot_parameters['vertex.label.cex'] <- 0.9
   plot_parameters['vertex.label.dist'] <- 1.4
 
+  labels <- FALSE
+  if (!(is.null(vertex_attr(g, "label")))) {
+    labels <- TRUE
+  }
+  
   if (input$graph_names_check == FALSE) {
-    plot_parameters[['vertex.label']] = ifelse(V(g)$id %in% selected_row_names, ifelse(nchar(V(g)$name) > 0, V(g)$name, "-"), NA)
+    if (labels) {
+      plot_parameters[['vertex.label']] <- ifelse(V(g)$id %in% selected_row_names, ifelse(nchar(V(g)$label) > 0, V(g)$label, "-"), NA)
+    } else {
+      plot_parameters[['vertex.label']] <- ifelse(V(g)$id %in% selected_row_names, ifelse(nchar(V(g)$name) > 0, V(g)$name, "-"), NA)
+    }
   } else {
-    plot_parameters[['vertex.label']] <- ifelse(nchar(V(g)$name) > 0, V(g)$name, "-")
+    if (labels) {
+      plot_parameters[['vertex.label']] <- ifelse(nchar(V(g)$label) > 0, V(g)$label, "-")
+    } else {
+      plot_parameters[['vertex.label']] <- ifelse(nchar(V(g)$name) > 0, V(g)$name, "-")
+    }
   }
   plot_parameters[['vertex.label.color']] = ifelse(V(g)$id %in% selected_row_names, g_plot_selected_vertex_color, g_plot_default_label_color)
 

--- a/VOSONDash/sml.R
+++ b/VOSONDash/sml.R
@@ -96,11 +96,11 @@ createTwitterActorNetwork <- function(data) {
   
   network <- data %>% Create("actor", verbose = TRUE)
   # latest version uses named lists
-  if (getVosonSMLVersion("0.26.0")) {
+  # if (getVosonSMLVersion("0.26.0")) {
     network <- network$graph
-  } else {
-    network <- network$g
-  }
+  # } else {
+  #  network <- network$g
+  # }
   
   network <- set.graph.attribute(network,"type", "twitter")
   

--- a/VOSONDash/sml.R
+++ b/VOSONDash/sml.R
@@ -95,7 +95,13 @@ createTwitterActorNetwork <- function(data) {
   network <- NULL
   
   network <- data %>% Create("actor", verbose = TRUE)
-  network <- network$g
+  # latest version uses named lists
+  if (getVosonSMLVersion("0.26.0")) {
+    network <- network$graph
+  } else {
+    network <- network$g
+  }
+  
   network <- set.graph.attribute(network,"type", "twitter")
   
   networkWT <- network # with text data
@@ -152,8 +158,13 @@ createYoutubeNetwork <- function(data) {
   network <- NULL
   
   network <- data %>% Create('actor', writeToFile = FALSE)
-  
-  network <- set.graph.attribute(network, "type", "youtube")
+  # latest version uses named lists
+  if (getVosonSMLVersion("0.26.0")) {
+    network <- network$graph
+  }
+
+  # network <- set.graph.attribute(network, "type", "youtube")
+  network <- igraph::set_graph_attr(network, "type", "youtube")
   
   # Rob started work on getting text data into network, but needs to make change to vosonSML (comment id as edge attribute)
   networkWT <- network # with text data
@@ -193,6 +204,12 @@ createRedditActorNetwork <- function(data) {
   
   network <- data %>% Create("actor", writeToFile = FALSE)
   networkWT <- data %>% Create("actor", textData = TRUE, writeToFile = FALSE)
+  
+  # latest version uses named lists
+  if (getVosonSMLVersion("0.26.0")) {
+    network <- network$graph
+    networkWT <- networkWT$graph 
+  }  
   
   return(list(network = network, networkWT = networkWT))
 }
@@ -238,11 +255,14 @@ getInfo <- function() {
   return(info)
 }
 
-getVosonSMLVersion <- function() {
-  info <- NULL
+getVosonSMLVersion <- function(compare_ver) {
   if ("vosonSML" %in% loadedNamespaces()) {
-    info <- packageVersion("vosonSML")
+    if (missing(compare_ver)) {
+      return(packageVersion("vosonSML"))
+    } else {
+      return(packageVersion("vosonSML") >= compare_ver)
+    }
+  } else {
+    return(NULL)
   }
-  
-  return(info)
 }


### PR DESCRIPTION
The `vosonSML` interface for `VOSONDash` was updated to support named list output from `Create` functions as now implemented in `vosonSML v0.26.2`.

Changes  include:
- Updated `sml.R` functions `createYoutubeNetwork` and `createRedditActorNetwork` to use the value of the named list attribute `$graph` returned from vosonSML `Create`. In previous versions an `igraph` object was returned. The function `createTwitterActorNetwork` was already using this format and did not require changes. These changes are compatible with `vosonSML v0.25.0`
- The function `getVosonSMLVersion` was changed to accept a `compare_ver` parameter as string that if provided returns `TRUE` if the installed `vosonSML` package version is greater or equal. If the parameter is missing the function returns the `vosonSML` package version.

Other changes:
- Modified the standard network graph and the `visNetwork` graphs to use node labels instead of names if they are present in the graph data. This change is most notable with twitter graphs that were previously displaying twitter user id's as node labels and now use the label attribute (set to screen names during network creation).