### PR TITLE
Renamed bimodal network to twomode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: VOSONDash
-Version: 0.5.0
+Version: 0.5.1
 Title: User Interface for Collecting and Analysing Social Networks
 Description: A 'Shiny' application for the interactive visualisation and
     analysis of networks that also provides a web interface for collecting

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# VOSONDash 0.5.1
+
+## Minor Changes:
+- Renamed `bimodal` networks to `twomode`.
+
 # VOSONDash 0.5.0
 
 ## Major Changes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Minor Changes:
 - Renamed `bimodal` networks to `twomode`.
+- Added percentage sliders to twitter `semantic` network creation tab.
 
 # VOSONDash 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Downloads](https://cranlogs.r-pkg.org/badges/VOSONDash)
 ![Total](https://cranlogs.r-pkg.org/badges/grand-total/VOSONDash)
 ![Github Release](https://img.shields.io/github/release-pre/vosonlab/VOSONDash.svg?logo=github&colorB=8065ac)
-![Dev](https://img.shields.io/static/v1?label=dev&message=v0.5.0&color=orange&logo=github)
+![Dev](https://img.shields.io/static/v1?label=dev&message=v0.5.1&color=orange&logo=github)
 ![Last Commit](https://img.shields.io/github/last-commit/vosonlab/VOSONDash.svg?logo=github)
 
 `VOSONDash` is an interactive [R Shiny](https://shiny.rstudio.com/) web application for the visualisation and analysis of social network data. The app has a dashboard layout with sections for visualising and manipulating network graphs, performing text analysis, displaying network metrics and the collection of network data using the [vosonSML](https://github.com/vosonlab/vosonSML) R package.
@@ -12,21 +12,20 @@
 
 `VOSONDash` is an R package and must be installed before the app can be run.
 
-Install the latest release via CRAN:
+Install the latest release via CRAN (v0.4.4):
 ```R
 install.packages("VOSONDash")
 ```
 
-Install the latest release via GitHub:
+Install the latest release via GitHub (v0.5.0):
 ```R
 install.packages("https://github.com/vosonlab/VOSONDash/releases/download/v0.5.0/VOSONDash-0.5.0.tar.gz", 
   repo = NULL, type = "source")
 ```
 
-Install the latest development version:
+Install the latest development version (v0.5.1):
 ```R
 # library(devtools)
-
 devtools::install_github("vosonlab/VOSONDash")
 ```
 
@@ -34,7 +33,6 @@ Once the VOSON Dashboard package is installed and loaded the Shiny web applicati
 
 ```R
 library(VOSONDash)
-
 runVOSONDash()
 ```
 
@@ -49,9 +47,7 @@ For example:
 =================================================
 VOSONDash v0.4.4
 01 Aug 2019 09:35
-
 ...
-
 Checking packages...
 
 Error: Required packages missing.
@@ -63,7 +59,6 @@ The missing packages can be installed using the provided package install command
 
 ```R
 Please install required packages before using VOSONDash:
-
 install.packages(c("visNetwork","syuzhet"))
 ```
 
@@ -91,7 +86,7 @@ Fig 1. Environmental activist site hyperlink network loaded from a `graphml` fil
 Graphical interfaces for collecting network data from social media API's.
 
 * Collect: Twitter, youtube and reddit network data
-* Create: different types of networks from the data such as activity, actor, bimodal and semantic networks
+* Create: different types of networks from the data such as activity, actor, twomode and semantic networks
 
 ![VOSONDash Twitter Collection](https://vosonlab.github.io/VOSONDash/images/collection-twitter-1420x980.jpg)
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="http://vosonlab.github.io/VOSONDash/index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 
@@ -109,18 +109,15 @@
 <a class="sourceLine" id="cb5-2" title="2"><span class="op">==</span><span class="er">===============================================</span></a>
 <a class="sourceLine" id="cb5-3" title="3">VOSONDash v0.<span class="fl">4.4</span></a>
 <a class="sourceLine" id="cb5-4" title="4"><span class="dv">01</span> Aug <span class="dv">2019</span> <span class="dv">09</span><span class="op">:</span><span class="dv">35</span></a>
-<a class="sourceLine" id="cb5-5" title="5"></a>
-<a class="sourceLine" id="cb5-6" title="6">...</a>
+<a class="sourceLine" id="cb5-5" title="5">...</a>
+<a class="sourceLine" id="cb5-6" title="6">Checking packages...</a>
 <a class="sourceLine" id="cb5-7" title="7"></a>
-<a class="sourceLine" id="cb5-8" title="8">Checking packages...</a>
-<a class="sourceLine" id="cb5-9" title="9"></a>
-<a class="sourceLine" id="cb5-10" title="10">Error<span class="op">:</span><span class="st"> </span>Required packages missing.</a>
-<a class="sourceLine" id="cb5-11" title="11"><span class="op">-</span><span class="st"> </span>visNetwork</a>
-<a class="sourceLine" id="cb5-12" title="12"><span class="op">-</span><span class="st"> </span>syuzhet</a></code></pre></div>
+<a class="sourceLine" id="cb5-8" title="8">Error<span class="op">:</span><span class="st"> </span>Required packages missing.</a>
+<a class="sourceLine" id="cb5-9" title="9"><span class="op">-</span><span class="st"> </span>visNetwork</a>
+<a class="sourceLine" id="cb5-10" title="10"><span class="op">-</span><span class="st"> </span>syuzhet</a></code></pre></div>
 <p>The missing packages can be installed using the provided package install command.</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" title="1">Please install required packages before using VOSONDash<span class="op">:</span></a>
-<a class="sourceLine" id="cb6-2" title="2"></a>
-<a class="sourceLine" id="cb6-3" title="3"><span class="kw"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"visNetwork"</span>,<span class="st">"syuzhet"</span>))</a></code></pre></div>
+<a class="sourceLine" id="cb6-2" title="2"><span class="kw"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"visNetwork"</span>,<span class="st">"syuzhet"</span>))</a></code></pre></div>
 <p>After installing required packages and running again the <code>VOSONDash</code> Shiny app will open up in the default web browser.</p>
 </div>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,25 +83,23 @@
 <div id="vosondash" class="section level1">
 <div class="page-header"><h1 class="hasAnchor">
 <a href="#vosondash" class="anchor"></a>VOSONDash</h1></div>
-<p><a href="https://CRAN.R-project.org/package=VOSONDash"><img src="https://www.r-pkg.org/badges/version/VOSONDash" alt="CRAN_Status_Badge"></a> <img src="https://cranlogs.r-pkg.org/badges/VOSONDash" alt="Downloads"><img src="https://cranlogs.r-pkg.org/badges/grand-total/VOSONDash" alt="Total"><img src="https://img.shields.io/github/release-pre/vosonlab/VOSONDash.svg?logo=github&amp;colorB=8065ac" alt="Github Release"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.5.0&amp;color=orange&amp;logo=github" alt="Dev"><img src="https://img.shields.io/github/last-commit/vosonlab/VOSONDash.svg?logo=github" alt="Last Commit"></p>
+<p><a href="https://CRAN.R-project.org/package=VOSONDash"><img src="https://www.r-pkg.org/badges/version/VOSONDash" alt="CRAN_Status_Badge"></a> <img src="https://cranlogs.r-pkg.org/badges/VOSONDash" alt="Downloads"><img src="https://cranlogs.r-pkg.org/badges/grand-total/VOSONDash" alt="Total"><img src="https://img.shields.io/github/release-pre/vosonlab/VOSONDash.svg?logo=github&amp;colorB=8065ac" alt="Github Release"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.5.1&amp;color=orange&amp;logo=github" alt="Dev"><img src="https://img.shields.io/github/last-commit/vosonlab/VOSONDash.svg?logo=github" alt="Last Commit"></p>
 <p><code>VOSONDash</code> is an interactive <a href="https://shiny.rstudio.com/">R Shiny</a> web application for the visualisation and analysis of social network data. The app has a dashboard layout with sections for visualising and manipulating network graphs, performing text analysis, displaying network metrics and the collection of network data using the <a href="https://github.com/vosonlab/vosonSML">vosonSML</a> R package.</p>
 <div id="installation" class="section level2">
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p><code>VOSONDash</code> is an R package and must be installed before the app can be run.</p>
-<p>Install the latest release via CRAN:</p>
+<p>Install the latest release via CRAN (v0.4.4):</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" title="1"><span class="kw"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"VOSONDash"</span>)</a></code></pre></div>
-<p>Install the latest release via GitHub:</p>
+<p>Install the latest release via GitHub (v0.5.0):</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" title="1"><span class="kw"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/VOSONDash/releases/download/v0.5.0/VOSONDash-0.5.0.tar.gz"</span>, </a>
 <a class="sourceLine" id="cb2-2" title="2">  <span class="dt">repo =</span> <span class="ot">NULL</span>, <span class="dt">type =</span> <span class="st">"source"</span>)</a></code></pre></div>
-<p>Install the latest development version:</p>
+<p>Install the latest development version (v0.5.1):</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" title="1"><span class="co"># library(devtools)</span></a>
-<a class="sourceLine" id="cb3-2" title="2"></a>
-<a class="sourceLine" id="cb3-3" title="3">devtools<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/devtools/man/remote-reexports.html">install_github</a></span>(<span class="st">"vosonlab/VOSONDash"</span>)</a></code></pre></div>
+<a class="sourceLine" id="cb3-2" title="2">devtools<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/devtools/man/remote-reexports.html">install_github</a></span>(<span class="st">"vosonlab/VOSONDash"</span>)</a></code></pre></div>
 <p>Once the VOSON Dashboard package is installed and loaded the Shiny web application can be run from the RStudio console using the <code><a href="reference/runVOSONDash.html">runVOSONDash()</a></code> function.</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" title="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(VOSONDash)</a>
-<a class="sourceLine" id="cb4-2" title="2"></a>
-<a class="sourceLine" id="cb4-3" title="3"><span class="kw"><a href="reference/runVOSONDash.html">runVOSONDash</a></span>()</a></code></pre></div>
+<a class="sourceLine" id="cb4-2" title="2"><span class="kw"><a href="reference/runVOSONDash.html">runVOSONDash</a></span>()</a></code></pre></div>
 <div id="running-the-app-for-the-first-time" class="section level3">
 <h3 class="hasAnchor">
 <a href="#running-the-app-for-the-first-time" class="anchor"></a>Running the app for the first time</h3>
@@ -149,7 +147,7 @@
 <p>Graphical interfaces for collecting network data from social media API’s.</p>
 <ul>
 <li>Collect: Twitter, youtube and reddit network data</li>
-<li>Create: different types of networks from the data such as activity, actor, bimodal and semantic networks</li>
+<li>Create: different types of networks from the data such as activity, actor, twomode and semantic networks</li>
 </ul>
 <p><img src="https://vosonlab.github.io/VOSONDash/images/collection-twitter-1420x980.jpg" alt="VOSONDash Twitter Collection"></p>
 <p>Fig 2. Collection of recent <code>#auspol</code> tweets and generation of an actor network with the <code>vosonSML</code> package.</p>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 
@@ -129,6 +129,7 @@
 <a href="#minor-changes" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Renamed <code>bimodal</code> networks to <code>twomode</code>.</li>
+<li>Added percentage sliders to twitter <code>semantic</code> network creation tab.</li>
 </ul>
 </div>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -120,6 +120,18 @@
       <small>Source: <a href='https://github.com/vosonlab/VOSONDash/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="vosondash-051" class="section level1">
+<h1 class="page-header">
+<a href="#vosondash-051" class="anchor"></a>VOSONDash 0.5.1<small> Unreleased </small>
+</h1>
+<div id="minor-changes" class="section level2">
+<h2 class="hasAnchor">
+<a href="#minor-changes" class="anchor"></a>Minor Changes:</h2>
+<ul>
+<li>Renamed <code>bimodal</code> networks to <code>twomode</code>.</li>
+</ul>
+</div>
+</div>
     <div id="vosondash-050" class="section level1">
 <h1 class="page-header">
 <a href="#vosondash-050" class="anchor"></a>VOSONDash 0.5.0<small> Unreleased </small>
@@ -162,9 +174,9 @@
 <p><br>Refer to <code>vosonSML</code> documentation for further information on network types and options at <a href="https://vosonlab.github.io/vosonSML/reference/index.html" class="uri">https://vosonlab.github.io/vosonSML/reference/index.html</a>.</p>
 </div>
 </div>
-<div id="minor-changes" class="section level2">
+<div id="minor-changes-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-1" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Added a new <code>Collect</code> data download button named <code>Network</code> to allow the <code>nodes</code> and <code>edges</code> dataframes to be downloaded after <code>Create Network</code>. The data is downloaded as an R object in a <code>.rds</code> file that can be loaded into R using the <code><a href="https://rdrr.io/r/base/readRDS.html">readRDS()</a></code> function.</li>
 </ul>
@@ -181,9 +193,9 @@
 <h1 class="page-header">
 <a href="#vosondash-044" class="anchor"></a>VOSONDash 0.4.4<small> 2019-08-09 </small>
 </h1>
-<div id="minor-changes-1" class="section level2">
+<div id="minor-changes-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-1" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-2" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Changed the required package check to be more efficient by calling <code>required()</code> instead of <code><a href="https://rdrr.io/r/utils/installed.packages.html">installed.packages()</a></code>.</li>
 <li>Changed the app startup messages to use <code><a href="https://rdrr.io/r/base/message.html">message()</a></code> instead of <code><a href="https://rdrr.io/r/base/cat.html">cat()</a></code> so if desired they can be suppressed.</li>
@@ -198,9 +210,9 @@
 <h1 class="page-header">
 <a href="#vosondash-043" class="anchor"></a>VOSONDash 0.4.3<small> Unreleased </small>
 </h1>
-<div id="minor-changes-2" class="section level2">
+<div id="minor-changes-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-2" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-3" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Changed the node size controls in <code>Network Graphs</code> to be based on normalized continuous values.</li>
 <li>Moved the calculation of network metrics to the <code><a href="../reference/getNetworkMetrics.html">getNetworkMetrics()</a></code> package function.</li>
@@ -232,9 +244,9 @@
 <li>A twitter web authorization token can now be created and used for API access without the need for a Developer account. This still requires a twitter app and Consumer API keys but means if a user has access to these that the user can authorize the twitter app against their account and use <code>VOSONDash</code> to perform twitter collections. Using this token API rate-limiting will be applied to the users account not the app. Twitter refers to this method of authentication as ‘Application-user authentication: OAuth 1a (access token for user context)’. This feature uses the <code>rtweet</code> packages interactive web authorization as implemented by the <code><a href="https://rdrr.io/pkg/rtweet/man/create_token.html">rtweet::create_token</a></code> function. As stated above once a token has been created it should be saved and re-used.</li>
 </ul>
 </div>
-<div id="minor-changes-3" class="section level2">
+<div id="minor-changes-4" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-3" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-4" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Demonstration data has been included in the package and is accessible by a new selection box below the graphml file loader in <code>Network Graphs</code>. If there is a file with the same name as the demonstration graphml file but with an additional ‘.txt’ extension in the packages demonstration data folder it will be loaded as the graph description.</li>
 <li>Added graph summary information for <code>Network Graphs</code> plots as an overlay in the bottom left corner.</li>
@@ -255,6 +267,7 @@
     <div id="tocnav">
       <h2>Contents</h2>
       <ul class="nav nav-pills nav-stacked">
+        <li><a href="#vosondash-051">0.5.1</a></li>
         <li><a href="#vosondash-050">0.5.0</a></li>
         <li><a href="#vosondash-044">0.4.4</a></li>
         <li><a href="#vosondash-043">0.4.3</a></li>

--- a/docs/reference/VOSONDash-package.html
+++ b/docs/reference/VOSONDash-package.html
@@ -75,7 +75,7 @@ data using the vosonSML R package." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/addAdditionalMeasures.html
+++ b/docs/reference/addAdditionalMeasures.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/applyCategoricalFilters.html
+++ b/docs/reference/applyCategoricalFilters.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/applyComponentFilter.html
+++ b/docs/reference/applyComponentFilter.html
@@ -72,7 +72,7 @@ component size range." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/applyGraphFilters.html
+++ b/docs/reference/applyGraphFilters.html
@@ -72,7 +72,7 @@ graph." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/applyPruneFilter.html
+++ b/docs/reference/applyPruneFilter.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/collectRedditData.html
+++ b/docs/reference/collectRedditData.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/collectTwitterData.html
+++ b/docs/reference/collectTwitterData.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/collectYoutubeData.html
+++ b/docs/reference/collectYoutubeData.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/createRedditActorNetwork.html
+++ b/docs/reference/createRedditActorNetwork.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/createRedditRequestUrl.html
+++ b/docs/reference/createRedditRequestUrl.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/createTokenId.html
+++ b/docs/reference/createTokenId.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterActorNetwork.html
+++ b/docs/reference/createTwitterActorNetwork.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterDevToken.html
+++ b/docs/reference/createTwitterDevToken.html
@@ -73,7 +73,7 @@ management." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterWebToken.html
+++ b/docs/reference/createTwitterWebToken.html
@@ -73,7 +73,7 @@ type and created are added to the credential object to assist with VOSONDash tok
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/createYoutubeNetwork.html
+++ b/docs/reference/createYoutubeNetwork.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/emptyPlotMessage.html
+++ b/docs/reference/emptyPlotMessage.html
@@ -73,7 +73,7 @@ aesthetic." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/getNetworkMetrics.html
+++ b/docs/reference/getNetworkMetrics.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/getRedditUrlSubreddit.html
+++ b/docs/reference/getRedditUrlSubreddit.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/getRedditUrlThreadId.html
+++ b/docs/reference/getRedditUrlThreadId.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/getVOSONDashVer.html
+++ b/docs/reference/getVOSONDashVer.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/getVertexCategories.html
+++ b/docs/reference/getVertexCategories.html
@@ -72,7 +72,7 @@ format and their unique values." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/getVosonSMLVersion.html
+++ b/docs/reference/getVosonSMLVersion.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/getYoutubeVideoId.html
+++ b/docs/reference/getYoutubeVideoId.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/hasVosonTextData.html
+++ b/docs/reference/hasVosonTextData.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/isMac.html
+++ b/docs/reference/isMac.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/isNullOrEmpty.html
+++ b/docs/reference/isNullOrEmpty.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/isVosonSML0290.html
+++ b/docs/reference/isVosonSML0290.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/loadDemoGraph.html
+++ b/docs/reference/loadDemoGraph.html
@@ -72,7 +72,7 @@ VOSONDash package by file name." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/logMessage.html
+++ b/docs/reference/logMessage.html
@@ -72,7 +72,7 @@ stored. The queue stores count messages based on first in first out." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/mixmat.html
+++ b/docs/reference/mixmat.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/runVOSONDash.html
+++ b/docs/reference/runVOSONDash.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/systemTimeFilename.html
+++ b/docs/reference/systemTimeFilename.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/wordCloudPlot.html
+++ b/docs/reference/wordCloudPlot.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/wordFreqChart.html
+++ b/docs/reference/wordFreqChart.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/wordSentChart.html
+++ b/docs/reference/wordSentChart.html
@@ -73,7 +73,7 @@ percentage." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/docs/reference/wordSentValenceChart.html
+++ b/docs/reference/wordSentValenceChart.html
@@ -72,7 +72,7 @@ valence in a text corpus." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.1</span>
       </span>
     </div>
 

--- a/inst/vosondash/modules/collectionModule.R
+++ b/inst/vosondash/modules/collectionModule.R
@@ -18,7 +18,7 @@ collectNetworkButtonsUI <- function(id) {
 }
 
 collectGraphButtonsUI <- function(id) {
-  if (v029) { collectGraphButtonsUI_(id) }
+  if (v029) { return(collectGraphButtonsUI_(id)) }
   ns <- NS(id)
   
   tagList(
@@ -37,7 +37,7 @@ collectGraphButtonsUI_ <- function(id) {
 }
 
 collectViewGraphButtonsUI <- function(id) {
-  if (v029) { collectViewGraphButtonsUI_(id) }
+  if (v029) { return(collectViewGraphButtonsUI_(id)) }
   ns <- NS(id)
   
   tagList(

--- a/inst/vosondash/server/twitterServer.R
+++ b/inst/vosondash/server/twitterServer.R
@@ -229,23 +229,23 @@ observeEvent(input$twitter_create_button, {
       if (add_user_data) { 
         network <- vosonSML::AddUserData(network, isolate(tw_rv$tw_data), twitterAuth = creds_rv$use_token) 
       }
-    } else if (net_type == "bimodal") {
-      rem_terms <- parse_rem_terms(input$twitter_bimodal_remove)
+    } else if (net_type == "twomode") {
+      rem_terms <- parse_rem_terms(input$twitter_twomode_remove)
       if (length(rem_terms)) {
-        network <- vosonSML::Create(isolate(tw_rv$tw_data), "bimodal", removeTermsOrHashtags = rem_terms,
+        network <- vosonSML::Create(isolate(tw_rv$tw_data), "twomode", removeTermsOrHashtags = rem_terms,
                                     verbose = TRUE)
       } else {
-        network <- vosonSML::Create(isolate(tw_rv$tw_data), "bimodal", verbose = TRUE) 
+        network <- vosonSML::Create(isolate(tw_rv$tw_data), "twomode", verbose = TRUE) 
       }
     } else if (net_type == "semantic") {
       rem_terms <- parse_rem_terms(input$twitter_semantic_remove)
 
-      if (length(rem_terms)) {
-        network <- vosonSML::Create(isolate(tw_rv$tw_data), "semantic", removeTermsOrHashtags = rem_terms,
-                                    verbose = TRUE)
-      } else {
-        network <- vosonSML::Create(isolate(tw_rv$tw_data), "semantic", verbose = TRUE) 
-      }
+      network <- vosonSML::Create(isolate(tw_rv$tw_data), "semantic", 
+                                  removeTermsOrHashtags = rem_terms,
+                                  stopwordsEnglish = input$twitter_semantic_stopwords,
+                                  termFreq = input$twitter_term_freq,
+                                  hashtagFreq = input$twitter_hashtag_freq,
+                                  verbose = TRUE)
     }
     if (!is.null(network)) {
       tw_rv$tw_network <- network

--- a/inst/vosondash/ui/twitterUI.R
+++ b/inst/vosondash/ui/twitterUI.R
@@ -73,7 +73,7 @@ tabItem(tabName = "twitter_collection_tab",
                                 
                           ), # end tabPanel
                           tabPanel("Create Network",
-                                   selectInput("twitter_network_type_select", label = "Network", choices = c("activity", "actor", "bimodal", "semantic"), multiple = FALSE),
+                                   selectInput("twitter_network_type_select", label = "Network", choices = c("activity", "actor", "twomode", "semantic"), multiple = FALSE),
                                    conditionalPanel(
                                            condition = "input.twitter_network_type_select == 'activity' || 
                                                         input.twitter_network_type_select == 'actor'",
@@ -84,16 +84,21 @@ tabItem(tabName = "twitter_collection_tab",
                                            checkboxInput("twitter_network_user_data", "Lookup User Data", FALSE)
                                    ),
                                    conditionalPanel(
-                                           condition = "input.twitter_network_type_select == 'bimodal'",
-                                           textAreaInput("twitter_bimodal_remove", label = "Remove Terms", value = "",
+                                           condition = "input.twitter_network_type_select == 'twomode'",
+                                           textAreaInput("twitter_twomode_remove", label = "Remove Terms", value = "",
                                                      width = NULL, height = NULL,
                                                      cols = NULL, rows = 2, placeholder = NULL, resize = "vertical")
                                    ),
                                    conditionalPanel(
                                            condition = "input.twitter_network_type_select == 'semantic'",
+                                           checkboxInput("twitter_semantic_stopwords", "Remove English stopwords", TRUE),
                                            textAreaInput("twitter_semantic_remove", label = "Remove Terms", value = "",
                                                      width = NULL, height = NULL,
-                                                     cols = NULL, rows = 2, placeholder = NULL, resize = "vertical")
+                                                     cols = NULL, rows = 2, placeholder = NULL, resize = "vertical"),
+                                           sliderInput("twitter_term_freq", "% Most Frequent Words", 1, 100, value = 5, step = 1,
+                                                       round = TRUE),
+                                           sliderInput("twitter_hashtag_freq", "% Most Frequent Hashtags", 1, 100, value = 50, step = 1,
+                                                       round = TRUE)
                                    ),
                                    p(""),
                                    disabled(actionButton("twitter_create_button", label = "Create Network", icon = icon("share-alt")))


### PR DESCRIPTION
Minor Changes:
- Renamed the `bimodal` network to the more frequently used name `two mode` network.
- Added sliders for the twitter `semantic` network most frequent percentage words and hashtags to include in network.
- Fixed `Collect` buttons to remove redundant `+text` options from previous version.  