### PR TITLE
Fixed issue with dplyr and custom class dataframes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: VOSONDash
-Version: 0.5.4
+Version: 0.5.5
 Title: User Interface for Collecting and Analysing Social Networks
 Description: A 'Shiny' application for the interactive visualisation and
     analysis of networks that also provides a web interface for collecting

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# VOSONDash 0.5.5
+
+## Bug Fixes:
+- Fixed an issue with custom classes assigned to dataframes causing an vctrs error when using dplyr functions. The classes are not required so they are simply removed.
+
 # VOSONDash 0.5.4
 
 ## Minor Changes:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Downloads](https://cranlogs.r-pkg.org/badges/VOSONDash)](https://CRAN.R-project.org/package=VOSONDash)
 [![Total](https://cranlogs.r-pkg.org/badges/grand-total/VOSONDash)](https://CRAN.R-project.org/package=VOSONDash)
 [![Github Release](https://img.shields.io/github/release-pre/vosonlab/VOSONDash.svg?logo=github&colorB=8065ac)](https://github.com/vosonlab/VOSONDash/releases)
-[![Dev](https://img.shields.io/static/v1?label=dev&message=v0.5.4&color=659DBD&logo=github)](https://github.com/vosonlab/VOSONDash)
+[![Dev](https://img.shields.io/static/v1?label=dev&message=v0.5.5&color=659DBD&logo=github)](https://github.com/vosonlab/VOSONDash)
 [![Last Commit](https://img.shields.io/github/last-commit/vosonlab/VOSONDash.svg?color=659DBD&logo=github)](https://github.com/vosonlab/VOSONDash/commits/master)
 
 `VOSONDash` is an interactive [R Shiny](https://shiny.rstudio.com/) web application for the visualisation and analysis of social network data. The app has a dashboard layout with sections for visualising and manipulating network graphs, performing text analysis, displaying network metrics and the collection of network data using the [vosonSML](https://github.com/vosonlab/vosonSML) R package.
@@ -17,13 +17,13 @@ Install the latest release via CRAN (v0.5.4):
 install.packages("VOSONDash")
 ```
 
-Install the latest release via GitHub (v0.5.4):
+Install the latest release via GitHub (v0.5.5):
 ```R
-install.packages("https://github.com/vosonlab/VOSONDash/releases/download/v0.5.4/VOSONDash-0.5.4.tar.gz", 
+install.packages("https://github.com/vosonlab/VOSONDash/releases/download/v0.5.5/VOSONDash-0.5.5.tar.gz", 
   repo = NULL, type = "source")
 ```
 
-Install the latest development version (v0.5.4):
+Install the latest development version (v0.5.5):
 ```R
 # library(devtools)
 devtools::install_github("vosonlab/VOSONDash")
@@ -45,7 +45,7 @@ For example:
 ```R
 > runVOSONDash()
 =================================================
-VOSONDash v0.5.3
+VOSONDash v0.5.5
 ...
 Checking packages...
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="http://vosonlab.github.io/VOSONDash/index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 
@@ -124,12 +124,12 @@
 <p><code>VOSONDash</code> is an R package and must be installed before the app can be run.</p>
 <p>Install the latest release via CRAN (v0.5.4):</p>
 <div class="sourceCode" id="cb1"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"VOSONDash"</span>)</pre></div>
-<p>Install the latest release via GitHub (v0.5.4):</p>
-<div class="sourceCode" id="cb2"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/VOSONDash/releases/download/v0.5.4/VOSONDash-0.5.4.tar.gz"</span>,
+<p>Install the latest release via GitHub (v0.5.5):</p>
+<div class="sourceCode" id="cb2"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/VOSONDash/releases/download/v0.5.5/VOSONDash-0.5.5.tar.gz"</span>,
   <span class="kw">repo</span> <span class="kw">=</span> <span class="kw">NULL</span>, <span class="kw">type</span> <span class="kw">=</span> <span class="st">"source"</span>)</pre></div>
-<p>Install the latest development version (v0.5.4):</p>
+<p>Install the latest development version (v0.5.5):</p>
 <div class="sourceCode" id="cb3"><pre class="r"><span class="co"># library(devtools)</span>
-<span class="kw pkg">devtools</span><span class="kw ns">::</span><span class="fu"><a href="https://devtools.r-lib.org//reference/remote-reexports.html">install_github</a></span>(<span class="st">"vosonlab/VOSONDash"</span>)</pre></div>
+<span class="kw pkg">devtools</span><span class="kw ns">::</span><span class="fu">install_github</span>(<span class="st">"vosonlab/VOSONDash"</span>)</pre></div>
 <p>Once the VOSON Dashboard package is installed and loaded the Shiny web application can be run from the RStudio console using the <code><a href="reference/runVOSONDash.html">runVOSONDash()</a></code> function.</p>
 <div class="sourceCode" id="cb4"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/base/library.html">library</a></span>(<span class="no">VOSONDash</span>)
 <span class="fu"><a href="reference/runVOSONDash.html">runVOSONDash</a></span>()</pre></div>
@@ -140,7 +140,7 @@
 <p>For example:</p>
 <div class="sourceCode" id="cb5"><pre class="r">&gt; runVOSONDash()
 =================================================
-VOSONDash v0.5.3
+VOSONDash v0.5.5
 ...
 Checking packages...
 
@@ -235,7 +235,7 @@ install.packages(c("visNetwork","syuzhet"))</pre></div>
 <li><a href="https://CRAN.R-project.org/package=VOSONDash"><img src="https://cranlogs.r-pkg.org/badges/VOSONDash" alt="Downloads"></a></li>
 <li><a href="https://CRAN.R-project.org/package=VOSONDash"><img src="https://cranlogs.r-pkg.org/badges/grand-total/VOSONDash" alt="Total"></a></li>
 <li><a href="https://github.com/vosonlab/VOSONDash/releases"><img src="https://img.shields.io/github/release-pre/vosonlab/VOSONDash.svg?logo=github&amp;colorB=8065ac" alt="Github Release"></a></li>
-<li><a href="https://github.com/vosonlab/VOSONDash"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.5.4&amp;color=659DBD&amp;logo=github" alt="Dev"></a></li>
+<li><a href="https://github.com/vosonlab/VOSONDash"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.5.5&amp;color=659DBD&amp;logo=github" alt="Dev"></a></li>
 <li><a href="https://github.com/vosonlab/VOSONDash/commits/master"><img src="https://img.shields.io/github/last-commit/vosonlab/VOSONDash.svg?color=659DBD&amp;logo=github" alt="Last Commit"></a></li>
 </ul>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 
@@ -157,9 +157,21 @@
       <small>Source: <a href='https://github.com/vosonlab/VOSONDash/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="vosondash-055" class="section level1">
+<h1 class="page-header" data-toc-text="0.5.5">
+<a href="#vosondash-055" class="anchor"></a>VOSONDash 0.5.5<small> Unreleased </small>
+</h1>
+<div id="bug-fixes" class="section level2">
+<h2 class="hasAnchor">
+<a href="#bug-fixes" class="anchor"></a>Bug Fixes:</h2>
+<ul>
+<li>Fixed an issue with custom classes assigned to dataframes causing an vctrs error when using dplyr functions. The classes are not required so they are simply removed.</li>
+</ul>
+</div>
+</div>
     <div id="vosondash-054" class="section level1">
 <h1 class="page-header" data-toc-text="0.5.4">
-<a href="#vosondash-054" class="anchor"></a>VOSONDash 0.5.4<small> Unreleased </small>
+<a href="#vosondash-054" class="anchor"></a>VOSONDash 0.5.4<small> 2020-05-20 </small>
 </h1>
 <div id="minor-changes" class="section level2">
 <h2 class="hasAnchor">
@@ -199,9 +211,9 @@
 <li>Moved <code>rtweet</code> from package imports to suggests.</li>
 </ul>
 </div>
-<div id="bug-fixes" class="section level2">
+<div id="bug-fixes-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fixes" class="anchor"></a>Bug Fixes:</h2>
+<a href="#bug-fixes-1" class="anchor"></a>Bug Fixes:</h2>
 <ul>
 <li>Fixed <code>reddit</code> URL formatting to support retrieving additional threads.</li>
 </ul>
@@ -269,9 +281,9 @@
 <li>Added a new <code>Collect</code> data download button named <code>Network</code> to allow the <code>nodes</code> and <code>edges</code> dataframes to be downloaded after <code>Create Network</code>. The data is downloaded as an R object in a <code>.rds</code> file that can be loaded into R using the <code><a href="https://rdrr.io/r/base/readRDS.html">readRDS()</a></code> function.</li>
 </ul>
 </div>
-<div id="bug-fixes-1" class="section level2">
+<div id="bug-fixes-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fixes-1" class="anchor"></a>Bug Fixes:</h2>
+<a href="#bug-fixes-2" class="anchor"></a>Bug Fixes:</h2>
 <ul>
 <li>Fixed the console scrolling in the <code>Collect</code> section of the interface to scroll to the bottom when there is new text output.</li>
 </ul>
@@ -314,9 +326,9 @@
 <h1 class="page-header" data-toc-text="0.4.2">
 <a href="#vosondash-042" class="anchor"></a>VOSONDash 0.4.2<small> Unreleased </small>
 </h1>
-<div id="bug-fixes-2" class="section level2">
+<div id="bug-fixes-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fixes-2" class="anchor"></a>Bug Fixes:</h2>
+<a href="#bug-fixes-3" class="anchor"></a>Bug Fixes:</h2>
 <ul>
 <li>Fixed problem with <code>visNetwork</code> graphs rendering slightly off the canvas.</li>
 </ul>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,7 +2,7 @@ pandoc: 2.9.2
 pkgdown: 1.5.1
 pkgdown_sha: ~
 articles: []
-last_built: 2020-05-20T08:11Z
+last_built: 2020-06-14T12:14Z
 urls:
   reference: http://vosonlab.github.io/VOSONDash/reference
   article: http://vosonlab.github.io/VOSONDash/articles

--- a/docs/reference/VOSONDash-package.html
+++ b/docs/reference/VOSONDash-package.html
@@ -85,7 +85,7 @@ data using the vosonSML R package." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/addAdditionalMeasures.html
+++ b/docs/reference/addAdditionalMeasures.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/applyCategoricalFilters.html
+++ b/docs/reference/applyCategoricalFilters.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/applyComponentFilter.html
+++ b/docs/reference/applyComponentFilter.html
@@ -82,7 +82,7 @@ component size range." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/applyGraphFilters.html
+++ b/docs/reference/applyGraphFilters.html
@@ -82,7 +82,7 @@ graph." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/applyPruneFilter.html
+++ b/docs/reference/applyPruneFilter.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/collectRedditData.html
+++ b/docs/reference/collectRedditData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/collectTwitterData.html
+++ b/docs/reference/collectTwitterData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/collectYoutubeData.html
+++ b/docs/reference/collectYoutubeData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/createRedditActorNetwork.html
+++ b/docs/reference/createRedditActorNetwork.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/createRedditRequestUrl.html
+++ b/docs/reference/createRedditRequestUrl.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/createTokenId.html
+++ b/docs/reference/createTokenId.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterActorNetwork.html
+++ b/docs/reference/createTwitterActorNetwork.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterDevToken.html
+++ b/docs/reference/createTwitterDevToken.html
@@ -83,7 +83,7 @@ management." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterWebToken.html
+++ b/docs/reference/createTwitterWebToken.html
@@ -83,7 +83,7 @@ type and created are added to the credential object to assist with VOSONDash tok
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/createYoutubeNetwork.html
+++ b/docs/reference/createYoutubeNetwork.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/emptyPlotMessage.html
+++ b/docs/reference/emptyPlotMessage.html
@@ -83,7 +83,7 @@ aesthetic." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/getNetworkMetrics.html
+++ b/docs/reference/getNetworkMetrics.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/getRedditUrlSubreddit.html
+++ b/docs/reference/getRedditUrlSubreddit.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/getRedditUrlThreadId.html
+++ b/docs/reference/getRedditUrlThreadId.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/getVOSONDashVer.html
+++ b/docs/reference/getVOSONDashVer.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/getVertexCategories.html
+++ b/docs/reference/getVertexCategories.html
@@ -82,7 +82,7 @@ format and their unique values." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/getVosonSMLVersion.html
+++ b/docs/reference/getVosonSMLVersion.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/getYoutubeVideoId.html
+++ b/docs/reference/getYoutubeVideoId.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/hasVosonTextData.html
+++ b/docs/reference/hasVosonTextData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/isMac.html
+++ b/docs/reference/isMac.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/isNullOrEmpty.html
+++ b/docs/reference/isNullOrEmpty.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/isVosonSML0290.html
+++ b/docs/reference/isVosonSML0290.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/loadDemoGraph.html
+++ b/docs/reference/loadDemoGraph.html
@@ -82,7 +82,7 @@ VOSONDash package by file name." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/logMessage.html
+++ b/docs/reference/logMessage.html
@@ -82,7 +82,7 @@ stored. The queue stores count messages based on first in first out." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/mixmat.html
+++ b/docs/reference/mixmat.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/runVOSONDash.html
+++ b/docs/reference/runVOSONDash.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/systemTimeFilename.html
+++ b/docs/reference/systemTimeFilename.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/wordCloudPlot.html
+++ b/docs/reference/wordCloudPlot.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/wordFreqChart.html
+++ b/docs/reference/wordFreqChart.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/wordSentChart.html
+++ b/docs/reference/wordSentChart.html
@@ -83,7 +83,7 @@ percentage." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/docs/reference/wordSentValenceChart.html
+++ b/docs/reference/wordSentValenceChart.html
@@ -82,7 +82,7 @@ valence in a text corpus." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.4</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
       </span>
     </div>
 

--- a/inst/vosondash/server/redditServer.R
+++ b/inst/vosondash/server/redditServer.R
@@ -225,9 +225,13 @@ datatableRedditData <- reactive({
   
   if (is.null(data)) { return(NULL) }
   
+  cls_lst <- class(data)
+  class(data) <- cls_lst[!cls_lst %in% c("datasource", "reddit")]
+  
   if (!is.null(input$show_reddit_cols)) {
     if (length(input$show_reddit_cols) > 0) {
-      data <- dplyr::select(red_rv$reddit_data, input$show_reddit_cols)
+      # data <- dplyr::select(red_rv$reddit_data, input$show_reddit_cols)
+      data <- dplyr::select(data, input$show_reddit_cols)
     } else { return(NULL) }
   } else { return(NULL) }
   

--- a/inst/vosondash/server/twitterServer.R
+++ b/inst/vosondash/server/twitterServer.R
@@ -399,10 +399,13 @@ datatableTwitterData <- reactive({
   
   if (is.null(data)) { return(NULL) }
   
+  cls_lst <- class(data)
+  class(data) <- cls_lst[!cls_lst %in% c("datasource", "twitter")]
+  
   if (!is.null(input$show_twitter_cols)) {
     if (length(input$show_twitter_cols) > 0) {
-      data <- dplyr::select(tw_rv$tw_data, input$show_twitter_cols)
-    
+      # data <- dplyr::select(tw_rv$tw_data, input$show_twitter_cols)
+      data <- dplyr::select(data, input$show_twitter_cols)
     } else { return(NULL) }
   } else { return(NULL) }
   

--- a/inst/vosondash/server/youtubeServer.R
+++ b/inst/vosondash/server/youtubeServer.R
@@ -270,9 +270,13 @@ datatableYoutubeData <- reactive({
   
   if (is.null(data)) { return(NULL) }
   
+  cls_lst <- class(data)
+  class(data) <- cls_lst[!cls_lst %in% c("datasource", "youtube")]
+  
   if (!is.null(input$show_youtube_cols)) {
     if (length(input$show_youtube_cols) > 0) {
-      data <- dplyr::select(yt_rv$yt_data, input$show_youtube_cols)
+      # data <- dplyr::select(yt_rv$yt_data, input$show_youtube_cols)
+      data <- dplyr::select(data, input$show_youtube_cols)
     } else { return(NULL) }
   } else { return(NULL) }
   


### PR DESCRIPTION
Breaking changes in the latest dplyr update requires that when extending dataframes that extra classes are added first, not last. Additional classes are now removed during before selecting and loading collected data into DT's as they are not required.