### PR TITLE
CRAN package version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: VOSONDash
-Version: 0.5.5
+Version: 0.5.6
 Title: User Interface for Collecting and Analysing Social Networks
 Description: A 'Shiny' application for the interactive visualisation and
     analysis of networks that also provides a web interface for collecting
@@ -20,13 +20,19 @@ Imports:
     vosonSML (>= 0.29.0),
     wordcloud
 Suggests:
-    rtweet (>= 0.6.8)
+    dplyr,
+    DT,
+    htmlwidgets,
+    rtweet (>= 0.6.8),
+    shinydashboard,
+    shinyjs,
+    visNetwork
 Depends: R (>= 3.2.0)
 Encoding: UTF-8
 Author: Bryan Gertzel, Robert Ackland
 Maintainer: Bryan Gertzel <bryan.gertzel@anu.edu.au>
 License: GPL (>= 3)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 NeedsCompilation: no
 URL: https://github.com/vosonlab/VOSONDash
 BugReports: https://github.com/vosonlab/VOSONDash/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# VOSONDash 0.5.6
+
+## Minor Changes:
+- Set `visNetwork` plot edge width if weight column present in edges.
+- Removed arrows from `visNetwork` plot if graph undirected.
+- Fixed a groups parameter warning from `dplyr::summarise`. 
+- Cleaned up package dependencies.
+- CRAN version update.
+
 # VOSONDash 0.5.5
 
 ## Bug Fixes:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Downloads](https://cranlogs.r-pkg.org/badges/VOSONDash)](https://CRAN.R-project.org/package=VOSONDash)
 [![Total](https://cranlogs.r-pkg.org/badges/grand-total/VOSONDash)](https://CRAN.R-project.org/package=VOSONDash)
 [![Github Release](https://img.shields.io/github/release-pre/vosonlab/VOSONDash.svg?logo=github&colorB=8065ac)](https://github.com/vosonlab/VOSONDash/releases)
-[![Dev](https://img.shields.io/static/v1?label=dev&message=v0.5.5&color=659DBD&logo=github)](https://github.com/vosonlab/VOSONDash)
+[![Dev](https://img.shields.io/static/v1?label=dev&message=v0.5.6&color=659DBD&logo=github)](https://github.com/vosonlab/VOSONDash)
 [![Last Commit](https://img.shields.io/github/last-commit/vosonlab/VOSONDash.svg?color=659DBD&logo=github)](https://github.com/vosonlab/VOSONDash/commits/master)
 
 `VOSONDash` is an interactive [R Shiny](https://shiny.rstudio.com/) web application for the visualisation and analysis of social network data. The app has a dashboard layout with sections for visualising and manipulating network graphs, performing text analysis, displaying network metrics and the collection of network data using the [vosonSML](https://github.com/vosonlab/vosonSML) R package.
@@ -12,18 +12,18 @@
 
 `VOSONDash` is an R package and must be installed before the app can be run.
 
-Install the latest release via CRAN (v0.5.4):
+Install the latest release via CRAN (v0.5.6):
 ```R
 install.packages("VOSONDash")
 ```
 
-Install the latest release via GitHub (v0.5.5):
+Install the latest release via GitHub (v0.5.6):
 ```R
-install.packages("https://github.com/vosonlab/VOSONDash/releases/download/v0.5.5/VOSONDash-0.5.5.tar.gz", 
+install.packages("https://github.com/vosonlab/VOSONDash/releases/download/v0.5.5/VOSONDash-0.5.6.tar.gz", 
   repo = NULL, type = "source")
 ```
 
-Install the latest development version (v0.5.5):
+Install the latest development version (v0.5.6):
 ```R
 # library(devtools)
 devtools::install_github("vosonlab/VOSONDash")
@@ -45,7 +45,7 @@ For example:
 ```R
 > runVOSONDash()
 =================================================
-VOSONDash v0.5.5
+VOSONDash v0.5.6
 ...
 Checking packages...
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 `VOSONDash` is an R package and must be installed before the app can be run.
 
-Install the latest release via CRAN (v0.5.6):
+Install the latest release on CRAN (v0.5.4):
 ```R
 install.packages("VOSONDash")
 ```

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,8 @@
 ## Test environments
-* local MacOS X, R 4.0
-* local Windows 10, R 3.6.3
-* R-Devel r78492 Windows (Winbuilder)
-* R-Release 4.0 Windows (Winbuilder)
+* local MacOS X, R 4.0.2
+* local Windows 10, R 4.0.2
+* R-oldrelease (Winbuilder)
+* R-devel r78868 Windows (Winbuilder)
 
 ## R CMD check results
 0 errors | 0 warnings

--- a/docs/404.html
+++ b/docs/404.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="http://vosonlab.github.io/VOSONDash/index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 
@@ -122,12 +122,12 @@
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p><code>VOSONDash</code> is an R package and must be installed before the app can be run.</p>
-<p>Install the latest release via CRAN (v0.5.4):</p>
+<p>Install the latest release via CRAN (v0.5.6):</p>
 <div class="sourceCode" id="cb1"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"VOSONDash"</span>)</pre></div>
-<p>Install the latest release via GitHub (v0.5.5):</p>
-<div class="sourceCode" id="cb2"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/VOSONDash/releases/download/v0.5.5/VOSONDash-0.5.5.tar.gz"</span>,
+<p>Install the latest release via GitHub (v0.5.6):</p>
+<div class="sourceCode" id="cb2"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/VOSONDash/releases/download/v0.5.5/VOSONDash-0.5.6.tar.gz"</span>,
   <span class="kw">repo</span> <span class="kw">=</span> <span class="kw">NULL</span>, <span class="kw">type</span> <span class="kw">=</span> <span class="st">"source"</span>)</pre></div>
-<p>Install the latest development version (v0.5.5):</p>
+<p>Install the latest development version (v0.5.6):</p>
 <div class="sourceCode" id="cb3"><pre class="r"><span class="co"># library(devtools)</span>
 <span class="kw pkg">devtools</span><span class="kw ns">::</span><span class="fu">install_github</span>(<span class="st">"vosonlab/VOSONDash"</span>)</pre></div>
 <p>Once the VOSON Dashboard package is installed and loaded the Shiny web application can be run from the RStudio console using the <code><a href="reference/runVOSONDash.html">runVOSONDash()</a></code> function.</p>
@@ -140,7 +140,7 @@
 <p>For example:</p>
 <div class="sourceCode" id="cb5"><pre class="r">&gt; runVOSONDash()
 =================================================
-VOSONDash v0.5.5
+VOSONDash v0.5.6
 ...
 Checking packages...
 
@@ -235,7 +235,7 @@ install.packages(c("visNetwork","syuzhet"))</pre></div>
 <li><a href="https://CRAN.R-project.org/package=VOSONDash"><img src="https://cranlogs.r-pkg.org/badges/VOSONDash" alt="Downloads"></a></li>
 <li><a href="https://CRAN.R-project.org/package=VOSONDash"><img src="https://cranlogs.r-pkg.org/badges/grand-total/VOSONDash" alt="Total"></a></li>
 <li><a href="https://github.com/vosonlab/VOSONDash/releases"><img src="https://img.shields.io/github/release-pre/vosonlab/VOSONDash.svg?logo=github&amp;colorB=8065ac" alt="Github Release"></a></li>
-<li><a href="https://github.com/vosonlab/VOSONDash"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.5.5&amp;color=659DBD&amp;logo=github" alt="Dev"></a></li>
+<li><a href="https://github.com/vosonlab/VOSONDash"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.5.6&amp;color=659DBD&amp;logo=github" alt="Dev"></a></li>
 <li><a href="https://github.com/vosonlab/VOSONDash/commits/master"><img src="https://img.shields.io/github/last-commit/vosonlab/VOSONDash.svg?color=659DBD&amp;logo=github" alt="Last Commit"></a></li>
 </ul>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 
@@ -157,6 +157,21 @@
       <small>Source: <a href='https://github.com/vosonlab/VOSONDash/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="vosondash-056" class="section level1">
+<h1 class="page-header" data-toc-text="0.5.6">
+<a href="#vosondash-056" class="anchor"></a>VOSONDash 0.5.6<small> Unreleased </small>
+</h1>
+<div id="minor-changes" class="section level2">
+<h2 class="hasAnchor">
+<a href="#minor-changes" class="anchor"></a>Minor Changes:</h2>
+<ul>
+<li>Set <code>visNetwork</code> plot edge width if weight column present in edges.</li>
+<li>Fixed a new group warning from <code><a href="https://dplyr.tidyverse.org/reference/summarise.html">dplyr::summarise</a></code>.</li>
+<li>Cleaned up package dependencies.</li>
+<li>CRAN version update.</li>
+</ul>
+</div>
+</div>
     <div id="vosondash-055" class="section level1">
 <h1 class="page-header" data-toc-text="0.5.5">
 <a href="#vosondash-055" class="anchor"></a>VOSONDash 0.5.5<small> Unreleased </small>
@@ -173,9 +188,9 @@
 <h1 class="page-header" data-toc-text="0.5.4">
 <a href="#vosondash-054" class="anchor"></a>VOSONDash 0.5.4<small> 2020-05-20 </small>
 </h1>
-<div id="minor-changes" class="section level2">
+<div id="minor-changes-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-1" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Removed code support for older <code>vosonSML</code> versions prior to <code>0.29</code>.</li>
 <li>Code refactoring and removal of <code>networkD3</code> plots.</li>
@@ -187,9 +202,9 @@
 <h1 class="page-header" data-toc-text="0.5.3">
 <a href="#vosondash-053" class="anchor"></a>VOSONDash 0.5.3<small> Unreleased </small>
 </h1>
-<div id="minor-changes-1" class="section level2">
+<div id="minor-changes-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-1" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-2" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Added the option to inherit node colors from loaded <code>graphml</code> files in plots.</li>
 <li>Clicking nodes in the <code>visnetwork</code> plot now also selects or deselects them in the data table below it.</li>
@@ -204,9 +219,9 @@
 <h1 class="page-header" data-toc-text="0.5.2">
 <a href="#vosondash-052" class="anchor"></a>VOSONDash 0.5.2<small> Unreleased </small>
 </h1>
-<div id="minor-changes-2" class="section level2">
+<div id="minor-changes-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-2" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-3" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Moved <code>rtweet</code> from package imports to suggests.</li>
 </ul>
@@ -223,9 +238,9 @@
 <h1 class="page-header" data-toc-text="0.5.1">
 <a href="#vosondash-051" class="anchor"></a>VOSONDash 0.5.1<small> 2019-11-23 </small>
 </h1>
-<div id="minor-changes-3" class="section level2">
+<div id="minor-changes-4" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-3" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-4" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Renamed <code>bimodal</code> networks to <code>twomode</code>.</li>
 <li>Added percentage sliders to twitter <code>semantic</code> network creation tab.</li>
@@ -274,9 +289,9 @@
 <p><br>Refer to <code>vosonSML</code> documentation for further information on network types and options at <a href="https://vosonlab.github.io/vosonSML/reference/index.html" class="uri">https://vosonlab.github.io/vosonSML/reference/index.html</a>.</p>
 </div>
 </div>
-<div id="minor-changes-4" class="section level2">
+<div id="minor-changes-5" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-4" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-5" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Added a new <code>Collect</code> data download button named <code>Network</code> to allow the <code>nodes</code> and <code>edges</code> dataframes to be downloaded after <code>Create Network</code>. The data is downloaded as an R object in a <code>.rds</code> file that can be loaded into R using the <code><a href="https://rdrr.io/r/base/readRDS.html">readRDS()</a></code> function.</li>
 </ul>
@@ -293,9 +308,9 @@
 <h1 class="page-header" data-toc-text="0.4.4">
 <a href="#vosondash-044" class="anchor"></a>VOSONDash 0.4.4<small> 2019-08-09 </small>
 </h1>
-<div id="minor-changes-5" class="section level2">
+<div id="minor-changes-6" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-5" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-6" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Changed the required package check to be more efficient by calling <code>required()</code> instead of <code><a href="https://rdrr.io/r/utils/installed.packages.html">installed.packages()</a></code>.</li>
 <li>Changed the app startup messages to use <code><a href="https://rdrr.io/r/base/message.html">message()</a></code> instead of <code><a href="https://rdrr.io/r/base/cat.html">cat()</a></code> so if desired they can be suppressed.</li>
@@ -310,9 +325,9 @@
 <h1 class="page-header" data-toc-text="0.4.3">
 <a href="#vosondash-043" class="anchor"></a>VOSONDash 0.4.3<small> Unreleased </small>
 </h1>
-<div id="minor-changes-6" class="section level2">
+<div id="minor-changes-7" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-6" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-7" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Changed the node size controls in <code>Network Graphs</code> to be based on normalized continuous values.</li>
 <li>Moved the calculation of network metrics to the <code><a href="../reference/getNetworkMetrics.html">getNetworkMetrics()</a></code> package function.</li>
@@ -344,9 +359,9 @@
 <li>A twitter web authorization token can now be created and used for API access without the need for a Developer account. This still requires a twitter app and Consumer API keys but means if a user has access to these that the user can authorize the twitter app against their account and use <code>VOSONDash</code> to perform twitter collections. Using this token API rate-limiting will be applied to the users account not the app. Twitter refers to this method of authentication as ‘Application-user authentication: OAuth 1a (access token for user context)’. This feature uses the <code>rtweet</code> packages interactive web authorization as implemented by the <code><a href="https://rdrr.io/pkg/rtweet/man/create_token.html">rtweet::create_token</a></code> function. As stated above once a token has been created it should be saved and re-used.</li>
 </ul>
 </div>
-<div id="minor-changes-7" class="section level2">
+<div id="minor-changes-8" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-7" class="anchor"></a>Minor Changes:</h2>
+<a href="#minor-changes-8" class="anchor"></a>Minor Changes:</h2>
 <ul>
 <li>Demonstration data has been included in the package and is accessible by a new selection box below the graphml file loader in <code>Network Graphs</code>. If there is a file with the same name as the demonstration graphml file but with an additional ‘.txt’ extension in the packages demonstration data folder it will be loaded as the graph description.</li>
 <li>Added graph summary information for <code>Network Graphs</code> plots as an overlay in the bottom left corner.</li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,7 +2,7 @@ pandoc: 2.9.2
 pkgdown: 1.5.1
 pkgdown_sha: ~
 articles: []
-last_built: 2020-06-14T12:14Z
+last_built: 2020-07-18T10:20Z
 urls:
   reference: http://vosonlab.github.io/VOSONDash/reference
   article: http://vosonlab.github.io/VOSONDash/articles

--- a/docs/reference/VOSONDash-package.html
+++ b/docs/reference/VOSONDash-package.html
@@ -85,7 +85,7 @@ data using the vosonSML R package." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/addAdditionalMeasures.html
+++ b/docs/reference/addAdditionalMeasures.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/applyCategoricalFilters.html
+++ b/docs/reference/applyCategoricalFilters.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/applyComponentFilter.html
+++ b/docs/reference/applyComponentFilter.html
@@ -82,7 +82,7 @@ component size range." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/applyGraphFilters.html
+++ b/docs/reference/applyGraphFilters.html
@@ -82,7 +82,7 @@ graph." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/applyPruneFilter.html
+++ b/docs/reference/applyPruneFilter.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/collectRedditData.html
+++ b/docs/reference/collectRedditData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/collectTwitterData.html
+++ b/docs/reference/collectTwitterData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/collectYoutubeData.html
+++ b/docs/reference/collectYoutubeData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/createRedditActorNetwork.html
+++ b/docs/reference/createRedditActorNetwork.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/createRedditRequestUrl.html
+++ b/docs/reference/createRedditRequestUrl.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/createTokenId.html
+++ b/docs/reference/createTokenId.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterActorNetwork.html
+++ b/docs/reference/createTwitterActorNetwork.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterDevToken.html
+++ b/docs/reference/createTwitterDevToken.html
@@ -83,7 +83,7 @@ management." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/createTwitterWebToken.html
+++ b/docs/reference/createTwitterWebToken.html
@@ -83,7 +83,7 @@ type and created are added to the credential object to assist with VOSONDash tok
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/createYoutubeNetwork.html
+++ b/docs/reference/createYoutubeNetwork.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/emptyPlotMessage.html
+++ b/docs/reference/emptyPlotMessage.html
@@ -83,7 +83,7 @@ aesthetic." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/getNetworkMetrics.html
+++ b/docs/reference/getNetworkMetrics.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/getRedditUrlSubreddit.html
+++ b/docs/reference/getRedditUrlSubreddit.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/getRedditUrlThreadId.html
+++ b/docs/reference/getRedditUrlThreadId.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/getVOSONDashVer.html
+++ b/docs/reference/getVOSONDashVer.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/getVertexCategories.html
+++ b/docs/reference/getVertexCategories.html
@@ -82,7 +82,7 @@ format and their unique values." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/getVosonSMLVersion.html
+++ b/docs/reference/getVosonSMLVersion.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/getYoutubeVideoId.html
+++ b/docs/reference/getYoutubeVideoId.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/hasVosonTextData.html
+++ b/docs/reference/hasVosonTextData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/isMac.html
+++ b/docs/reference/isMac.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/isNullOrEmpty.html
+++ b/docs/reference/isNullOrEmpty.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/isVosonSML0290.html
+++ b/docs/reference/isVosonSML0290.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/loadDemoGraph.html
+++ b/docs/reference/loadDemoGraph.html
@@ -82,7 +82,7 @@ VOSONDash package by file name." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/logMessage.html
+++ b/docs/reference/logMessage.html
@@ -82,7 +82,7 @@ stored. The queue stores count messages based on first in first out." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/mixmat.html
+++ b/docs/reference/mixmat.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/runVOSONDash.html
+++ b/docs/reference/runVOSONDash.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/systemTimeFilename.html
+++ b/docs/reference/systemTimeFilename.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/wordCloudPlot.html
+++ b/docs/reference/wordCloudPlot.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/wordFreqChart.html
+++ b/docs/reference/wordFreqChart.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/wordSentChart.html
+++ b/docs/reference/wordSentChart.html
@@ -83,7 +83,7 @@ percentage." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/docs/reference/wordSentValenceChart.html
+++ b/docs/reference/wordSentValenceChart.html
@@ -82,7 +82,7 @@ valence in a text corpus." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">VOSONDash</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.5</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.5.6</span>
       </span>
     </div>
 

--- a/inst/vosondash/packages.R
+++ b/inst/vosondash/packages.R
@@ -1,13 +1,13 @@
 # required packages
-requiredPackages <- c("htmlwidgets",
+requiredPackages <- c("dplyr",
+                      "DT",
+                      "htmlwidgets",
+                      "igraph",
+                      "RColorBrewer",
                       "shinydashboard",
                       "shinyjs",
-                      "DT",
-                      "igraph",
-                      "visNetwork",
                       "tm",
-                      "dplyr",
-                      "RColorBrewer",
+                      "visNetwork",
                       "wordcloud")
 
 # if app is local print package information

--- a/inst/vosondash/server/networkGraphsServer.R
+++ b/inst/vosondash/server/networkGraphsServer.R
@@ -14,6 +14,8 @@ ng_rv <- reactiveValues(
   graph_name = "",
   graph_type = "",
   
+  graph_dir = TRUE, # directed
+  
   graph_cats = c(),        # list of categories in the data # graph_CA
   graph_cat_selected = "", # selected category # graph_CA_selected
   
@@ -108,7 +110,10 @@ observeEvent(ng_rv$graph_data, {
       # if no labels set label to vertex name
       V(ng_rv$graph_data)$label <- ifelse(nchar(V(ng_rv$graph_data)$name) > 0,
                                                V(ng_rv$graph_data)$name, "-")
-    }    
+    }
+    
+    # set directed
+    isolate({ ng_rv$graph_dir <- igraph::is_directed(ng_rv$graph_data) })
     
     # enable network metrics tab
     removeCssClass(selector = "a[data-value = 'network_metrics_tab']", class = "inactive_menu_link")


### PR DESCRIPTION
Version 0.5.5-6

Minor Changes:
- Set visNetwork plot edge width if weight column present in edges.
- Removed arrows from visNetwork plot if graph undirected.
- Fixed a groups parameter warning from dplyr::summarise.
- Cleaned up package dependencies.
- CRAN version update.

Bug Fixes:
- Fixed an issue with custom classes assigned to dataframes causing an vctrs error when using dplyr functions. The classes are not required so they are simply removed.